### PR TITLE
添加 NETStandard.Library引用

### DIFF
--- a/src/JT808.Protocol.Benchmark/JT808.Protocol.Benchmark.csproj
+++ b/src/JT808.Protocol.Benchmark/JT808.Protocol.Benchmark.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>

--- a/src/JT808.Protocol.Extensions.DependencyInjection/JT808.Protocol.Extensions.DependencyInjection.csproj
+++ b/src/JT808.Protocol.Extensions.DependencyInjection/JT808.Protocol.Extensions.DependencyInjection.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/JT808.Protocol.Test/JT808.Protocol.Test.csproj
+++ b/src/JT808.Protocol.Test/JT808.Protocol.Test.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />


### PR DESCRIPTION
在以下文件中添加NETStandard.Library（Version="2.0.3"） 引用，使NuGet可以自动还原依赖包。
src/JT808.Protocol.Benchmark/JT808.Protocol.Benchmark.csproj
src/JT808.Protocol.Extensions.DependencyInjection/JT808.Protocol.Extensions.DependencyInjection.csproj
src/JT808.Protocol.Test/JT808.Protocol.Test.csproj