### PR TITLE
Write PassthroughData directly instead of using JT808_0x8900/0900_BodyBase implementation

### DIFF
--- a/src/JT808.Protocol/MessageBody/JT808_0x0900.cs
+++ b/src/JT808.Protocol/MessageBody/JT808_0x0900.cs
@@ -93,8 +93,16 @@ namespace JT808.Protocol.MessageBody
         public void Serialize(ref JT808MessagePackWriter writer, JT808_0x0900 value, IJT808Config config)
         {
             writer.WriteByte(value.PassthroughType);
-            object obj = config.GetMessagePackFormatterByType(value.JT808_0x0900_BodyBase.GetType());
-            JT808MessagePackFormatterResolverExtensions.JT808DynamicSerialize(obj, ref writer, value.JT808_0x0900_BodyBase, config);
+
+            if ( value.JT808_0x0900_BodyBase != null )
+            {
+                object obj = config.GetMessagePackFormatterByType( value.JT808_0x0900_BodyBase.GetType() );
+                JT808MessagePackFormatterResolverExtensions.JT808DynamicSerialize( obj, ref writer, value.JT808_0x0900_BodyBase, config );
+            }
+            else
+            {
+                writer.WriteArray( value.PassthroughData );
+            }
         }
     }
 }

--- a/src/JT808.Protocol/MessageBody/JT808_0x8900.cs
+++ b/src/JT808.Protocol/MessageBody/JT808_0x8900.cs
@@ -63,7 +63,16 @@ namespace JT808.Protocol.MessageBody
         public void Serialize(ref JT808MessagePackWriter writer, JT808_0x8900 value, IJT808Config config)
         {
             writer.WriteByte(value.PassthroughType);
-            JT808MessagePackFormatterResolverExtensions.JT808DynamicSerialize(value.JT808_0X8900_BodyBase, ref writer, value.JT808_0X8900_BodyBase, config);
+
+            if ( value.JT808_0X8900_BodyBase != null )
+            {
+                JT808MessagePackFormatterResolverExtensions.JT808DynamicSerialize( value.JT808_0X8900_BodyBase, ref writer, value.JT808_0X8900_BodyBase, config );
+            }
+            else
+            {
+                writer.WriteArray( value.PassthroughData );
+            }
+
         }
         /// <summary>
         /// 


### PR DESCRIPTION
When creating an object of type `JT808_0x8900` or `JT808_0x0900` it should be possible to write directly the content to the `PassthroughData : byte []` instead of creating an implementation of `JT808_0x8900_BodyBase` or `JT808_0x0900_BodyBase`.